### PR TITLE
Revert bugs caused by fca39f and fix brightness scale

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -95,7 +95,8 @@ PRODUCT_PACKAGES += \
     android.hardware.bluetooth.audio@2.1.vendor \
     android.hardware.bluetooth@1.0.vendor \
     android.hardware.bluetooth@1.1.vendor \
-    android.hardware.bluetooth.audio-impl
+    android.hardware.bluetooth.audio@2.0-impl \
+    android.hardware.bluetooth.audio@2.1-impl
 
 # Boot Control
 PRODUCT_PACKAGES += \

--- a/manifest.xml
+++ b/manifest.xml
@@ -15,6 +15,11 @@
         <fqname>@1.1::IBluetoothHci/default</fqname>
     </hal>
     <hal format="hidl">
+        <name>android.hardware.bluetooth.audio</name>
+        <transport>hwbinder</transport>
+        <fqname>@2.1::IBluetoothAudioProvidersFactory/default</fqname>
+    </hal>
+    <hal format="hidl">
         <name>android.hardware.boot</name>
         <transport>hwbinder</transport>
         <fqname>@1.0::IBootControl/default</fqname>

--- a/rro_overlays/FrameworksResOverlayEvergo/res/values/config.xml
+++ b/rro_overlays/FrameworksResOverlayEvergo/res/values/config.xml
@@ -303,8 +303,10 @@
 
     <!-- Default screen brightness setting.
          Must be in the range specified by minimum and maximum. -->
-     <integer name="config_screenBrightnessSettingDefault">102</integer>
-
+     <integer name="config_screenBrightnessSettingDefault">1024</integer>
+     <!--Maxmimum screen brightness setting allowed by the power manager.
+         The user is forbidden from setting the brightness above this level. -->
+     <integer name="config_screenBrightnessSettingMaximum">2047</integer>
     <!-- Minimum screen brightness setting allowed by the power manager.
          The user is forbidden from setting the brightness below this level. -->
      <integer name="config_screenBrightnessSettingMinimum">10</integer>


### PR DESCRIPTION
Since the new aidl hal is broking the bt audio feature, we should revert the change of switching to aidl and use hidl.